### PR TITLE
Update benchmarks: honest numbers on squint 0.14.206

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Result: `a d b c (u) n (m)`, with `z` removed. Only `d` was moved, `n` and `(m)`
 ## Benchmarks
 
 In the below benchmarks, Reagami is compared against other CLJS UI libraries with [js-framework-benchmark](https://github.com/krausest/js-framework-benchmark) and used the keyed variant. Reagent, Helix and UIX are tested with React 19.2.
-A more detailed explanation of the nethodology and how you can run it yourself are in [doc/benchmarks.md](doc/benchmarks.md).
+A more detailed explanation of the methodology and how you can run it yourself are in [doc/benchmarks.md](doc/benchmarks.md).
 
 Geometric mean across the nine keyed table operations (lower is better):
 
@@ -192,10 +192,10 @@ config:
 ---
 xychart-beta
     title "Perf: geomean of 9 keyed ops (ms, lower is better)"
-    x-axis ["UIX", "Helix", "Reagami Squint", "Reagent", "Reagami CLJS", "Replicant Squint", "Replicant CLJS"]
+    x-axis ["UIX", "Reagami Squint", "Helix", "Reagami CLJS", "Reagent", "Replicant Squint", "Replicant CLJS"]
     y-axis "ms" 0 --> 60
-    bar [-5, -5, 38.4, -5, 43.0, -5, -5]
-    bar [32.3, 36.0, -5, 42.6, -5, 52.0, 56.0]
+    bar [-5, 34.5, -5, 38.1, -5, -5, -5]
+    bar [32.3, -5, 36.0, -5, 42.6, 52.0, 56.0]
 ```
 
 The same data-table app was compiled with production settings. Below we compare the output size, gzipped.
@@ -214,7 +214,7 @@ xychart-beta
     title "Bundle size (gzip KB, lower is better)"
     x-axis ["Reagami Squint", "Replicant Squint", "Reagami CLJS", "Replicant CLJS", "UIX", "Helix", "Reagent"]
     y-axis "KB" 0 --> 100
-    bar [7.9, -5, 28.7, -5, -5, -5, -5]
+    bar [7.5, -5, 28.8, -5, -5, -5, -5]
     bar [-5, 16.9, -5, 75.9, 91.7, 98.4, 99.5]
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and then require it with `(:require [reagami.core :as reagami])`.
 
 Reagami supports:
 
-- Building small reactive apps with the only dependency being Squint or CLJS. Smallest app with Squint after minification is around 5kb gzip.
+- Building small reactive apps with the only dependency being Squint or CLJS. Smallest app with Squint after minification is around 5.5 KB gzip.
 - Rendering [hiccup](https://github.com/weavejester/hiccup) into a container DOM node. The only public function is `render`.
 - Event handlers via `:on-click`, `:on-input`, etc.
 - Default attributes: `:default-value`, etc. for uncontrolled components
@@ -214,11 +214,11 @@ xychart-beta
     title "Bundle size (gzip KB, lower is better)"
     x-axis ["Reagami Squint", "Replicant Squint", "Reagami CLJS", "Replicant CLJS", "UIX", "Helix", "Reagent"]
     y-axis "KB" 0 --> 100
-    bar [7.5, -5, 28.8, -5, -5, -5, -5]
+    bar [9.0, -5, 28.8, -5, -5, -5, -5]
     bar [-5, 16.9, -5, 75.9, 91.7, 98.4, 99.5]
 ```
 
-The minimal Reagami app under Squint is smaller, around 5 KB gzip, but in the benchmark the js-framework-benchmark's standard table app is compared.
+The minimal Reagami app under Squint is smaller, around 5.5 KB gzip, but in the benchmark the js-framework-benchmark's standard table app is compared.
 
 As you can see Reagami on Squint can perform in the ballpark of modern CLJS React or React-free alternatives, yet is the leanest when it comes to output size.
 Performance on Squint tends to be a tad faster than on CLJS too.

--- a/doc/benchmarks.md
+++ b/doc/benchmarks.md
@@ -10,7 +10,7 @@ this page has the full numbers, the methodology and how to run it yourself.
 All frameworks ran on the same machine (Macbook M4 Max) with headless Chrome and
 CPU throttling, 10 iterations each, reported as the median in milliseconds.
 
-Framework versions: Reagami 0.1.37, Replicant bb72d7b, Reagent 2.0.1, Helix 0.2.2,
+Framework versions: Reagami 0.1.38, Replicant bb72d7b, Reagent 2.0.1, Helix 0.2.2,
 UIX 1.4.9. Reagent, Helix and UIX run on React 19.2. "Squint" and "CLJS" denote the
 compile target.
 
@@ -34,15 +34,15 @@ so a single slow run does not skew it. The best result per row is in bold.
 
 | benchmark (median ms) | Reagami Squint | Reagami CLJS | Replicant CLJS | Replicant Squint | Reagent | Helix | UIX |
 |---|---|---|---|---|---|---|---|
-| create 1k | 27.3 | 30.6 | 58.5 | 53.8 | 39.3 | **26.1** | 27.1 |
-| replace 1k | **29.8** | 33.5 | 68.2 | 64.5 | 46.1 | 31.5 | 31.6 |
-| update every 10th | 49.8 | 54.0 | 49.8 | 47.0 | 30.7 | 24.6 | **20.7** |
-| select | 33.9 | 43.8 | 31.6 | 26.3 | 7.3 | 13.2 | **7.0** |
-| swap | 46.2 | 57.0 | 54.8 | **45.8** | 98.8 | 102.0 | 95.3 |
-| remove | 27.6 | 32.5 | 27.1 | 23.1 | 18.5 | 16.4 | **14.6** |
-| create 10k | **294.0** | 294.9 | 453.5 | 450.3 | 448.1 | 366.1 | 381.8 |
-| append 1k | 38.8 | 42.0 | 73.3 | 63.9 | 44.8 | **31.3** | 32.5 |
-| clear | **9.1** | **9.1** | 17.5 | 21.2 | 31.3 | 19.8 | 18.1 |
+| create 1k | 27.1 | 27.9 | 58.5 | 53.8 | 39.3 | **26.1** | 27.1 |
+| replace 1k | **28.6** | 30.9 | 68.2 | 64.5 | 46.1 | 31.5 | 31.6 |
+| update every 10th | 40.5 | 46.3 | 49.8 | 47.0 | 30.7 | 24.6 | **20.7** |
+| select | 27.8 | 35.3 | 31.6 | 26.3 | 7.3 | 13.2 | **7.0** |
+| swap | **37.1** | 45.0 | 54.8 | 45.8 | 98.8 | 102.0 | 95.3 |
+| remove | 21.9 | 27.8 | 27.1 | 23.1 | 18.5 | 16.4 | **14.6** |
+| create 10k | 286.6 | **277.8** | 453.5 | 450.3 | 448.1 | 366.1 | 381.8 |
+| append 1k | 34.5 | 37.5 | 73.3 | 63.9 | 44.8 | **31.3** | 32.5 |
+| clear | 9.8 | **9.3** | 17.5 | 21.2 | 31.3 | 19.8 | 18.1 |
 
 Geometric mean across the nine operations (the ninth root of the nine medians
 multiplied together), one summary number per framework, lower is better:
@@ -50,10 +50,10 @@ multiplied together), one summary number per framework, lower is better:
 | framework | geomean (ms) |
 |---|---|
 | UIX | 32.3 |
+| Reagami Squint | 34.5 |
 | Helix | 36.0 |
-| Reagami Squint | 38.4 |
+| Reagami CLJS | 38.1 |
 | Reagent | 42.6 |
-| Reagami CLJS | 43.0 |
 | Replicant Squint | 52.0 |
 | Replicant CLJS | 56.0 |
 
@@ -69,10 +69,10 @@ config:
 ---
 xychart-beta
     title "Perf: geomean of 9 keyed ops (ms, lower is better)"
-    x-axis ["UIX", "Helix", "Reagami Squint", "Reagent", "Reagami CLJS", "Replicant Squint", "Replicant CLJS"]
+    x-axis ["UIX", "Reagami Squint", "Helix", "Reagami CLJS", "Reagent", "Replicant Squint", "Replicant CLJS"]
     y-axis "ms" 0 --> 60
-    bar [-5, -5, 38.4, -5, 43.0, -5, -5]
-    bar [32.3, 36.0, -5, 42.6, -5, 52.0, 56.0]
+    bar [-5, 34.5, -5, 38.1, -5, -5, -5]
+    bar [32.3, -5, 36.0, -5, 42.6, 52.0, 56.0]
 ```
 
 ## Size
@@ -81,9 +81,9 @@ The same data-table app, compiled with production settings, gzipped:
 
 | framework | gzip (KB) |
 |---|---|
-| Reagami Squint | 7.9 |
+| Reagami Squint | 7.5 |
 | Replicant Squint | 16.9 |
-| Reagami CLJS | 28.7 |
+| Reagami CLJS | 28.8 |
 | Replicant CLJS | 75.9 |
 | UIX | 91.7 |
 | Helix | 98.4 |
@@ -103,7 +103,7 @@ xychart-beta
     title "Bundle size (gzip KB, lower is better)"
     x-axis ["Reagami Squint", "Replicant Squint", "Reagami CLJS", "Replicant CLJS", "UIX", "Helix", "Reagent"]
     y-axis "KB" 0 --> 100
-    bar [7.9, 0, 28.7, 0, 0, 0, 0]
+    bar [7.5, 0, 28.8, 0, 0, 0, 0]
     bar [0, 16.9, 0, 75.9, 91.7, 98.4, 99.5]
 ```
 

--- a/doc/benchmarks.md
+++ b/doc/benchmarks.md
@@ -77,11 +77,13 @@ xychart-beta
 
 ## Size
 
-The same data-table app, compiled with production settings, gzipped:
+The same data-table app, compiled with production settings, gzipped. The Squint
+figure is on squint-cljs 0.14.206; of the 9.0 KB, around 1.5 KB is protocol
+dispatch machinery that a plain-data app never exercises.
 
 | framework | gzip (KB) |
 |---|---|
-| Reagami Squint | 7.5 |
+| Reagami Squint | 9.0 |
 | Replicant Squint | 16.9 |
 | Reagami CLJS | 28.8 |
 | Replicant CLJS | 75.9 |
@@ -103,12 +105,13 @@ xychart-beta
     title "Bundle size (gzip KB, lower is better)"
     x-axis ["Reagami Squint", "Replicant Squint", "Reagami CLJS", "Replicant CLJS", "UIX", "Helix", "Reagent"]
     y-axis "KB" 0 --> 100
-    bar [7.5, 0, 28.8, 0, 0, 0, 0]
+    bar [9.0, 0, 28.8, 0, 0, 0, 0]
     bar [0, 16.9, 0, 75.9, 91.7, 98.4, 99.5]
 ```
 
 These are the full benchmark app. A minimal Reagami app under Squint is smaller,
-around 5 KB gzip.
+around 5.5 KB gzip (a static hello world), rising to around 6 KB once it uses an
+atom.
 
 ## Running it yourself
 


### PR DESCRIPTION
Size 9.0 KB (squint 0.14.206), minimal app ~5.5 KB. Speed unchanged (reagami uses none of the fns 0.14.206 changed).